### PR TITLE
fixed artifact name in workflow

### DIFF
--- a/.github/workflows/pyinstaller_gui_mac.yaml
+++ b/.github/workflows/pyinstaller_gui_mac.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           # artifact name
-          name: CRIPT Excel Uploader Mac Zip
+          name: CRIPT_Excel_Uploader_Mac_Zip
           path: src/dist/
           if-no-files-found: error
           retention-days: 90


### PR DESCRIPTION
fixed artifact name in workflow to be "CRIPT_Excel_Uploader_Mac_Zip" instead of before when it would come out to "CRIPT.Excel.Uploader.Mac.Zip.zip"